### PR TITLE
add version in datalake table name

### DIFF
--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceConnector.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceConnector.java
@@ -30,6 +30,7 @@ public class DynamoDBSourceConnector extends SourceConnector {
     private TablesProvider tablesProvider;
 
     private List<String> consumableTables;
+    private String tableVersion;
 
     private volatile Timer timer;
 
@@ -76,7 +77,7 @@ public class DynamoDBSourceConnector extends SourceConnector {
                         config.getSrcDynamoDBEnvTagValue());
             }
         }
-
+        tableVersion = config.getTableVersion();
         startBackgroundReconfigurationTasks(this.context, config.getRediscoveryPeriod());
     }
 
@@ -135,7 +136,9 @@ public class DynamoDBSourceConnector extends SourceConnector {
             Map<String, String> taskProps = new HashMap<>(configProperties);
 
             taskProps.put(DynamoDBSourceTaskConfig.TABLE_NAME_CONFIG, table);
-
+            if (tableVersion != null && !tableVersion.isEmpty()) {
+                taskProps.put(DynamoDBSourceTaskConfig.TABLE_VERSION_CONFIG, tableVersion);
+            }
             // In feature we might allow having more then one task per table for performance reasons.
             // TaskID will be needed for KCL worker identifiers and also to orchestrate init sync.
             taskProps.put(DynamoDBSourceTaskConfig.TASK_ID_CONFIG, "task-1");

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceConnectorConfig.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceConnectorConfig.java
@@ -52,6 +52,11 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 	public static final String SRC_DYNAMODB_TABLE_WHITELIST_DISPLAY = "Tables whitelist";
 	public static final String SRC_DYNAMODB_TABLE_WHITELIST_DEFAULT = null;
 
+	public static final String SRC_DYNAMODB_TABLE_VERSION_CONFIG = "dynamodb.table.version";
+	public static final String SRC_DYNAMODB_TABLE_VERSION_DOC = "Define version of the table. This is used to create a unique table connector name for the table.";
+	public static final String SRC_DYNAMODB_TABLE_VERSION_DISPLAY = "Table version";
+	public static final String SRC_DYNAMODB_TABLE_VERSION_DEFAULT = "";
+
 	public static final String SRC_KCL_TABLE_BILLING_MODE_CONFIG = "kcl.table.billing.mode";
 	public static final String SRC_KCL_TABLE_BILLING_MODE_DOC = "Define billing mode for internal table created by the KCL library. Default is provisioned.";
 	public static final String SRC_KCL_TABLE_BILLING_MODE_DISPLAY = "KCL table billing mode";
@@ -176,6 +181,7 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 						ConfigDef.Width.MEDIUM,
 						SRC_DYNAMODB_TABLE_WHITELIST_DISPLAY)
 
+
 				.define(SRC_KCL_TABLE_BILLING_MODE_CONFIG,
 						ConfigDef.Type.STRING,
 						SRC_KCL_TABLE_BILLING_MODE_DEFAULT,
@@ -184,6 +190,15 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 						AWS_GROUP, 9,
 						ConfigDef.Width.MEDIUM,
 						SRC_KCL_TABLE_BILLING_MODE_DISPLAY)
+
+				.define(SRC_DYNAMODB_TABLE_VERSION_CONFIG,
+						ConfigDef.Type.STRING,
+						SRC_DYNAMODB_TABLE_VERSION_DEFAULT,
+						ConfigDef.Importance.LOW,
+						SRC_DYNAMODB_TABLE_VERSION_DOC,
+						AWS_GROUP, 10,
+						ConfigDef.Width.MEDIUM,
+						SRC_DYNAMODB_TABLE_VERSION_DISPLAY)
 
 				.define(DST_TOPIC_PREFIX_CONFIG,
 						ConfigDef.Type.STRING,
@@ -284,6 +299,10 @@ public class DynamoDBSourceConnectorConfig extends AbstractConfig {
 
 	public List<String> getWhitelistTables() {
 		return getList(SRC_DYNAMODB_TABLE_WHITELIST_CONFIG) != null ? getList(SRC_DYNAMODB_TABLE_WHITELIST_CONFIG) : null;
+	}
+
+	public String getTableVersion() {
+		return getString(SRC_DYNAMODB_TABLE_VERSION_CONFIG);
 	}
 
 	public BillingMode getKCLTableBillingMode() {

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTask.java
@@ -150,7 +150,7 @@ public class DynamoDBSourceTask extends SourceTask {
                     eventsQueue,
                     shardRegister);
         }
-        kclWorker.start(client, dynamoDBStreamsClient, tableDesc.getTableName(), config.getTaskID(), config.getDynamoDBServiceEndpoint(), config.getKCLTableBillingMode());
+        kclWorker.start(client, dynamoDBStreamsClient, tableDesc.getTableName(), config.getTaskID(), config.getDynamoDBServiceEndpoint(), config.getTableVersion(), config.getKCLTableBillingMode());
 
         shutdown = false;
     }

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskConfig.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskConfig.java
@@ -8,12 +8,16 @@ public class DynamoDBSourceTaskConfig extends DynamoDBSourceConnectorConfig {
     public static final String TABLE_NAME_CONFIG = "table";
     private static final String TABLE_NAME_DOC = "table for this task to watch for changes.";
 
+    public static final String TABLE_VERSION_CONFIG = "table.version";
+    private static final String TABLE_VERSION_DOC = "table version for this task to watch for changes.";
+
     public static final String TASK_ID_CONFIG = "task.id";
     private static final String TASK_ID_DOC = "Per table id of the task.";
 
     private static final ConfigDef config = baseConfigDef()
             .define(TABLE_NAME_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TABLE_NAME_DOC)
-            .define(TASK_ID_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TASK_ID_DOC);
+            .define(TASK_ID_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, TASK_ID_DOC)
+            .define(TABLE_VERSION_CONFIG, ConfigDef.Type.STRING, "", ConfigDef.Importance.LOW, TABLE_VERSION_DOC);
 
     public DynamoDBSourceTaskConfig(Map<String, String> props) {
         super(config, props);
@@ -21,6 +25,10 @@ public class DynamoDBSourceTaskConfig extends DynamoDBSourceConnectorConfig {
 
     public String getTableName() {
         return getString(TABLE_NAME_CONFIG);
+    }
+
+    public String getTableVersion() {
+        return getString(TABLE_VERSION_CONFIG);
     }
 
     public String getTaskID() {

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/SourceInfo.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/SourceInfo.java
@@ -114,12 +114,10 @@ public class SourceInfo {
         offset.put(INIT_SYNC_START, sourceInfo.lastInitSyncStart.toEpochMilli());
 
         if (sourceInfo.exclusiveStartKey != null) {
-            if (sourceInfo.exclusiveStartKey != null) {
             try {
                 offset.put(EXCLUSIVE_START_KEY, objectMapper.writeValueAsString(sourceInfo.exclusiveStartKey));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException("Failed to serialize exclusiveStartKey", e);
-            }
             }
             // offset.put(EXCLUSIVE_START_KEY, gson.toJson(sourceInfo.exclusiveStartKey));
         }

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclWorker.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclWorker.java
@@ -10,6 +10,7 @@ public interface KclWorker {
                String tableName,
                String taskid,
                String endpoint,
+               String tableVersion,
                BillingMode kclTablebillingMode);
 
     void stop();

--- a/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclWorkerImpl.java
+++ b/source/src/main/java/com/trustpilot/connector/dynamodb/kcl/KclWorkerImpl.java
@@ -49,13 +49,14 @@ public class KclWorkerImpl implements KclWorker {
                       String tableName,
                       String taskid,
                       String endpoint,
+                      String tableVersion,
                       BillingMode kclTableBillingMode) {
         IRecordProcessorFactory recordProcessorFactory = new KclRecordProcessorFactory(tableName, eventsQueue,
                 recordProcessorsRegister);
 
         KinesisClientLibConfiguration clientLibConfiguration = getClientLibConfiguration(tableName,
                 taskid,
-                dynamoDBClient, endpoint, kclTableBillingMode);
+                dynamoDBClient, endpoint, tableVersion, kclTableBillingMode);
 
         AmazonDynamoDBStreamsAdapterClient adapterClient = new AmazonDynamoDBStreamsAdapterClient(dynamoDBStreamsClient);
 
@@ -123,11 +124,16 @@ public class KclWorkerImpl implements KclWorker {
                                                             String taskid,
                                                             AmazonDynamoDB dynamoDBClient,
                                                             String endpoint,
+                                                            String tableVersion,
                                                             BillingMode kclTableBillingMode) {
 
         String streamArn = dynamoDBClient.describeTable(
                 new DescribeTableRequest()
                         .withTableName(tableName)).getTable().getLatestStreamArn();
+
+        if (tableVersion != null && !tableVersion.isEmpty()) {
+            tableName = tableName + "-" + tableVersion;
+        }
 
         return new KinesisClientLibConfiguration(
                 Constants.KCL_WORKER_APPLICATION_NAME_PREFIX + tableName,

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/DynamoDBSourceTaskTests.java
@@ -208,6 +208,7 @@ public class DynamoDBSourceTaskTests {
                 eq(tableName),
                 eq("testTask1"),
                 eq(null),
+                eq(""),
                 eq(BillingMode.PROVISIONED)
         );
     }

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/kcl/KclWorkerImplTests.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/kcl/KclWorkerImplTests.java
@@ -43,7 +43,7 @@ public class KclWorkerImplTests {
         when(dynamoDBClient.describeTable(ArgumentMatchers.<DescribeTableRequest>any())).thenReturn(result);
 
         // Act
-        KinesisClientLibConfiguration clientLibConfiguration = kclWorker.getClientLibConfiguration(tableName, taskId, dynamoDBClient, serviceEndpoint, kclTableBillingMode);
+        KinesisClientLibConfiguration clientLibConfiguration = kclWorker.getClientLibConfiguration(tableName, taskId, dynamoDBClient, serviceEndpoint, "", kclTableBillingMode);
 
         // Assert
         assertEquals("datalake-KCL-testTableName1", clientLibConfiguration.getApplicationName());


### PR DESCRIPTION
use this config to create table with suffix cdcv2

`datalake-KCL-test-dynamodb-connector-cdcv2`

```
{
    "name": "dynamodb-source",
    "config": {
        "connector.class": "com.trustpilot.connector.dynamodb.DynamoDBSourceConnector",
        "tasks.max": "1",
        "aws.region": "fakeRegion",
        "dynamodb.table.whitelist": "test-dynamodb-connector",
        "key.converter": "org.apache.kafka.connect.json.JsonConverter",
        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
        "key.converter.schemas.enable": "false",
        "value.converter.schemas.enable": "false",
        "aws.credentials.provider.class": "com.amazonaws.auth.profile.ProfileCredentialsProvider",
        "aws.credentials.provider.profile": "dynamo",
        "aws.access.key.id": "dummy",
        "aws.secret.key": "dummy",  
        "dynamodb.service.endpoint": "http://localhost:8000",
        "dynamodb.table.version": "cdcv2",
        "kafka.topic.prefix": "dynamodb-",
        "init.sync.delay.period": "60"
    }
}
```